### PR TITLE
cli/h5 https封装的axios get方法参数拼接问题

### DIFF
--- a/packages/@w6s/cli/templates/H5/template/src/utils/http/https.ts
+++ b/packages/@w6s/cli/templates/H5/template/src/utils/http/https.ts
@@ -51,10 +51,10 @@ export function apiGet<T>(
   // handleHeader
   let param = "?";
   Object.keys(handleData(params)).forEach((key) => {
-    param += handleData(params)[key];
+    param += `${key}=${handleData(params)[key]}&`;
   });
   return service
-    .get(`${url}${param}`, { headers })
+    .get(`${url}${param.substr(0, param.length - 1)}`, { headers })
     .then((res) => res)
     .catch((err) => {
       throw err;


### PR DESCRIPTION
fixed CLI/H5 https.ts get parameter concatenation bug